### PR TITLE
adding podspec

### DIFF
--- a/CoreMLHelpers.podspec
+++ b/CoreMLHelpers.podspec
@@ -1,0 +1,12 @@
+Pod::Spec.new do |s|
+  s.name         = "CoreMLHelpers"
+  s.version      = "0.1.0"
+  s.summary      = "Types and functions that make it a little easier to work with Core ML in Swift."
+  s.homepage     = "https://github.com/hollance/CoreMLHelpers"
+  s.license      = { :type => "MIT", :file => "LICENSE.txt" }
+  s.authors      = { "Matthijs Hollemans" => "matt@machinethink.net" }
+  s.source       = { :git => "https://github.com/hollance/CoreMLHelpers.git", :branch => 'master'}
+  s.source_files  = "CoreMLHelpers/**/*"
+  s.platform = :ios, '11.0'
+  s.swift_version = '4.0'
+end


### PR DESCRIPTION
Fix issue #2 

**What have been done:** 
Creates podspec which points to master branch, and allows pod integration with following specification：

pod 'CoreMLHelpers', :git => 'https://github.com/hollance/CoreMLHelpers.git'

**What need to do next:** 
1. Create tags and modify the podspec to point to latest tag 
2. Submit the pod to the CocoaPods master repo.