### PR TITLE
Changes for macOS

### DIFF
--- a/CoreMLHelpers/CGImage+CVPixelBuffer.swift
+++ b/CoreMLHelpers/CGImage+CVPixelBuffer.swift
@@ -1,0 +1,96 @@
+/*
+ Copyright (c) 2017 M.I. Hollemans
+ 
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to
+ deal in the Software without restriction, including without limitation the
+ rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ sell copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+ 
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+ 
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ IN THE SOFTWARE.
+ */
+
+#if canImport(CoreGraphics)
+
+import CoreGraphics
+import CoreImage
+import VideoToolbox
+
+extension CGImage {
+    /**
+     Creates a new CGImage from a CVPixelBuffer.
+     NOTE: This only works for RGB pixel buffers, not for grayscale.
+     */
+    public static func create(pixelBuffer: CVPixelBuffer) -> CGImage? {
+        var cgImage: CGImage?
+        VTCreateCGImageFromCVPixelBuffer(pixelBuffer, options: nil, imageOut: &cgImage)
+        return cgImage
+    }
+    
+    /**
+     Creates a new UIImage from a CVPixelBuffer, using Core Image.
+     */
+    public static func create(pixelBuffer: CVPixelBuffer, context: CIContext) -> CGImage? {
+        let ciImage = CIImage(cvPixelBuffer: pixelBuffer)
+        let rect = CGRect(x: 0, y: 0, width: CVPixelBufferGetWidth(pixelBuffer),
+                          height: CVPixelBufferGetHeight(pixelBuffer))
+        
+        return context.createCGImage(ciImage, from: rect)
+    }
+}
+
+extension CGImage {
+    /**
+     Creates a new CGImage from an array of RGBA bytes.
+     */
+    @nonobjc public class func fromByteArrayRGBA(_ bytes: [UInt8],
+                                                 width: Int,
+                                                 height: Int) -> CGImage? {
+        return fromByteArray(bytes, width: width, height: height,
+                             bytesPerRow: width * 4,
+                             colorSpace: CGColorSpaceCreateDeviceRGB(),
+                             alphaInfo: .premultipliedLast)
+    }
+    
+    /**
+     Creates a new CGImage from an array of grayscale bytes.
+     */
+    @nonobjc public class func fromByteArrayGray(_ bytes: [UInt8],
+                                                 width: Int,
+                                                 height: Int) -> CGImage? {
+        return fromByteArray(bytes, width: width, height: height,
+                             bytesPerRow: width,
+                             colorSpace: CGColorSpaceCreateDeviceGray(),
+                             alphaInfo: .none)
+    }
+    
+    @nonobjc class func fromByteArray(_ bytes: [UInt8],
+                                      width: Int,
+                                      height: Int,
+                                      bytesPerRow: Int,
+                                      colorSpace: CGColorSpace,
+                                      alphaInfo: CGImageAlphaInfo) -> CGImage? {
+        return bytes.withUnsafeBytes { ptr in
+            let context = CGContext(data: UnsafeMutableRawPointer(mutating: ptr.baseAddress!),
+                                    width: width,
+                                    height: height,
+                                    bitsPerComponent: 8,
+                                    bytesPerRow: bytesPerRow,
+                                    space: colorSpace,
+                                    bitmapInfo: alphaInfo.rawValue)
+            return context?.makeImage()
+        }
+    }
+}
+
+#endif

--- a/CoreMLHelpers/CGImage+CVPixelBuffer.swift
+++ b/CoreMLHelpers/CGImage+CVPixelBuffer.swift
@@ -28,6 +28,64 @@ import VideoToolbox
 
 extension CGImage {
     /**
+     Resizes the image to width x height and converts it to an RGB CVPixelBuffer.
+     */
+    public func pixelBuffer(width: Int, height: Int) -> CVPixelBuffer? {
+        return pixelBuffer(width: width, height: height,
+                           pixelFormatType: kCVPixelFormatType_32ARGB,
+                           colorSpace: CGColorSpaceCreateDeviceRGB(),
+                           alphaInfo: .noneSkipFirst)
+    }
+    
+    /**
+     Resizes the image to width x height and converts it to a grayscale CVPixelBuffer.
+     */
+    public func pixelBufferGray(width: Int, height: Int) -> CVPixelBuffer? {
+        return pixelBuffer(width: width, height: height,
+                           pixelFormatType: kCVPixelFormatType_OneComponent8,
+                           colorSpace: CGColorSpaceCreateDeviceGray(),
+                           alphaInfo: .none)
+    }
+    
+    func pixelBuffer(width: Int, height: Int, pixelFormatType: OSType,
+                     colorSpace: CGColorSpace, alphaInfo: CGImageAlphaInfo) -> CVPixelBuffer? {
+        var maybePixelBuffer: CVPixelBuffer?
+        let attrs = [kCVPixelBufferCGImageCompatibilityKey: kCFBooleanTrue,
+                     kCVPixelBufferCGBitmapContextCompatibilityKey: kCFBooleanTrue]
+        let status = CVPixelBufferCreate(kCFAllocatorDefault,
+                                         width,
+                                         height,
+                                         pixelFormatType,
+                                         attrs as CFDictionary,
+                                         &maybePixelBuffer)
+        
+        guard status == kCVReturnSuccess, let pixelBuffer = maybePixelBuffer else {
+            return nil
+        }
+        
+        CVPixelBufferLockBaseAddress(pixelBuffer, CVPixelBufferLockFlags(rawValue: 0))
+        let pixelData = CVPixelBufferGetBaseAddress(pixelBuffer)
+        
+        guard let context = CGContext(data: pixelData,
+                                      width: width,
+                                      height: height,
+                                      bitsPerComponent: 8,
+                                      bytesPerRow: CVPixelBufferGetBytesPerRow(pixelBuffer),
+                                      space: colorSpace,
+                                      bitmapInfo: alphaInfo.rawValue)
+            else {
+                return nil
+        }
+        
+        context.draw(self, in: CGRect(x: 0, y: 0, width: width, height: height))
+        
+        CVPixelBufferUnlockBaseAddress(pixelBuffer, CVPixelBufferLockFlags(rawValue: 0))
+        return pixelBuffer
+    }
+}
+
+extension CGImage {
+    /**
      Creates a new CGImage from a CVPixelBuffer.
      NOTE: This only works for RGB pixel buffers, not for grayscale.
      */

--- a/CoreMLHelpers/CGImage+CVPixelBuffer.swift
+++ b/CoreMLHelpers/CGImage+CVPixelBuffer.swift
@@ -20,8 +20,6 @@
  IN THE SOFTWARE.
  */
 
-#if canImport(CoreGraphics)
-
 import CoreGraphics
 import CoreImage
 import VideoToolbox
@@ -150,5 +148,3 @@ extension CGImage {
         }
     }
 }
-
-#endif

--- a/CoreMLHelpers/MLMultiArray+Image.swift
+++ b/CoreMLHelpers/MLMultiArray+Image.swift
@@ -20,8 +20,11 @@
   IN THE SOFTWARE.
 */
 
+#if canImport(UIKit)
+
 import Foundation
 import CoreML
+import UIKit
 
 extension MLMultiArray {
   /**
@@ -31,3 +34,5 @@ extension MLMultiArray {
     return MultiArray<T>(self).image(offset: offset, scale: scale)
   }
 }
+
+#endif

--- a/CoreMLHelpers/MLMultiArray+Image.swift
+++ b/CoreMLHelpers/MLMultiArray+Image.swift
@@ -20,10 +20,20 @@
   IN THE SOFTWARE.
 */
 
-#if canImport(UIKit)
-
 import Foundation
 import CoreML
+
+extension MLMultiArray {
+    /**
+     Converts the multi-array to a CGImage.
+     */
+    public func cgImage<T: MultiArrayType>(offset: T, scale: T) -> CGImage? {
+        return MultiArray<T>(self).cgImage(offset: offset, scale: scale)
+    }
+}
+
+#if canImport(UIKit)
+
 import UIKit
 
 extension MLMultiArray {

--- a/CoreMLHelpers/MultiArray.swift
+++ b/CoreMLHelpers/MultiArray.swift
@@ -20,9 +20,12 @@
   IN THE SOFTWARE.
 */
 
+#if canImport(UIKit)
+
 import Foundation
 import CoreML
 import Swift
+import UIKit
 
 public protocol MultiArrayType: Comparable {
   static var multiArrayDataType: MLMultiArrayDataType { get }
@@ -323,3 +326,5 @@ extension MultiArray {
     return a.image(offset: offset, scale: scale)
   }
 }
+
+#endif

--- a/CoreMLHelpers/MultiArray.swift
+++ b/CoreMLHelpers/MultiArray.swift
@@ -20,12 +20,9 @@
   IN THE SOFTWARE.
 */
 
-#if canImport(UIKit)
-
 import Foundation
 import CoreML
 import Swift
-import UIKit
 
 public protocol MultiArrayType: Comparable {
   static var multiArrayDataType: MLMultiArrayDataType { get }
@@ -216,26 +213,6 @@ extension MultiArray: CustomStringConvertible {
 
 extension MultiArray {
   /**
-   Converts the multi-array to a UIImage.
-
-   Use the `offset` and `scale` parameters to put the values from the array in
-   the range [0, 255]. The offset is added first, then the result is multiplied
-   by the scale.
-
-   For example: if the range of the data is [0, 1), use `offset: 0` and
-   `scale: 255`. If the range is [-1, 1], use `offset: 1` and `scale: 127.5`.
-  */
-  public func image(offset: T, scale: T) -> UIImage? {
-    if shape.count == 3, let (b, w, h) = toRawBytesRGBA(offset: offset, scale: scale) {
-      return UIImage.fromByteArrayRGBA(b, width: w, height: h)
-    } else if shape.count == 2, let (b, w, h) = toRawBytesGray(offset: offset, scale: scale) {
-      return UIImage.fromByteArrayGray(b, width: w, height: h)
-    } else {
-      return nil
-    }
-  }
-
-  /**
    Converts the multi-array into an array of RGBA pixels.
 
    - Note: The multi-array must have shape (3, height, width). If your array
@@ -298,33 +275,59 @@ extension MultiArray {
     }
     return (bytes, width, height)
   }
+}
 
-  /**
-   Converts a single channel from the multi-array to a grayscale UIImage.
+#if canImport(UIKit)
 
-   - Note: The multi-array must have shape (channels, height, width). If your
+import UIKit
+
+extension MultiArray {
+    /**
+     Converts the multi-array to a UIImage.
+     
+     Use the `offset` and `scale` parameters to put the values from the array in
+     the range [0, 255]. The offset is added first, then the result is multiplied
+     by the scale.
+     
+     For example: if the range of the data is [0, 1), use `offset: 0` and
+     `scale: 255`. If the range is [-1, 1], use `offset: 1` and `scale: 127.5`.
+     */
+    public func image(offset: T, scale: T) -> UIImage? {
+        if shape.count == 3, let (b, w, h) = toRawBytesRGBA(offset: offset, scale: scale) {
+            return UIImage.fromByteArrayRGBA(b, width: w, height: h)
+        } else if shape.count == 2, let (b, w, h) = toRawBytesGray(offset: offset, scale: scale) {
+            return UIImage.fromByteArrayGray(b, width: w, height: h)
+        } else {
+            return nil
+        }
+    }
+    
+    /**
+     Converts a single channel from the multi-array to a grayscale UIImage.
+     
+     - Note: The multi-array must have shape (channels, height, width). If your
      array has a different shape, use `reshape()` or `transpose()` first.
-  */
-  public func image(channel: Int, offset: T, scale: T) -> UIImage? {
-    guard shape.count == 3 else {
-      print("Expected a multi-array with 3 dimensions, got \(shape)")
-      return nil
+     */
+    public func image(channel: Int, offset: T, scale: T) -> UIImage? {
+        guard shape.count == 3 else {
+            print("Expected a multi-array with 3 dimensions, got \(shape)")
+            return nil
+        }
+        guard channel >= 0 && channel < shape[0] else {
+            print("Channel must be between 0 and \(shape[0] - 1)")
+            return nil
+        }
+        
+        let height = shape[1]
+        let width = shape[2]
+        var a = MultiArray<T>(shape: [height, width])
+        for y in 0..<height {
+            for x in 0..<width {
+                a[y, x] = self[channel, y, x]
+            }
+        }
+        return a.image(offset: offset, scale: scale)
     }
-    guard channel >= 0 && channel < shape[0] else {
-      print("Channel must be between 0 and \(shape[0] - 1)")
-      return nil
-    }
-
-    let height = shape[1]
-    let width = shape[2]
-    var a = MultiArray<T>(shape: [height, width])
-    for y in 0..<height {
-      for x in 0..<width {
-        a[y, x] = self[channel, y, x]
-      }
-    }
-    return a.image(offset: offset, scale: scale)
-  }
 }
 
 #endif

--- a/CoreMLHelpers/MultiArray.swift
+++ b/CoreMLHelpers/MultiArray.swift
@@ -277,13 +277,9 @@ extension MultiArray {
   }
 }
 
-#if canImport(UIKit)
-
-import UIKit
-
 extension MultiArray {
     /**
-     Converts the multi-array to a UIImage.
+     Converts the multi-array to a CGImage.
      
      Use the `offset` and `scale` parameters to put the values from the array in
      the range [0, 255]. The offset is added first, then the result is multiplied
@@ -292,23 +288,23 @@ extension MultiArray {
      For example: if the range of the data is [0, 1), use `offset: 0` and
      `scale: 255`. If the range is [-1, 1], use `offset: 1` and `scale: 127.5`.
      */
-    public func image(offset: T, scale: T) -> UIImage? {
+    public func cgImage(offset: T, scale: T) -> CGImage? {
         if shape.count == 3, let (b, w, h) = toRawBytesRGBA(offset: offset, scale: scale) {
-            return UIImage.fromByteArrayRGBA(b, width: w, height: h)
+            return CGImage.fromByteArrayRGBA(b, width: w, height: h)
         } else if shape.count == 2, let (b, w, h) = toRawBytesGray(offset: offset, scale: scale) {
-            return UIImage.fromByteArrayGray(b, width: w, height: h)
+            return CGImage.fromByteArrayGray(b, width: w, height: h)
         } else {
             return nil
         }
     }
     
     /**
-     Converts a single channel from the multi-array to a grayscale UIImage.
+     Converts a single channel from the multi-array to a grayscale CGImage.
      
      - Note: The multi-array must have shape (channels, height, width). If your
      array has a different shape, use `reshape()` or `transpose()` first.
      */
-    public func image(channel: Int, offset: T, scale: T) -> UIImage? {
+    public func cgImage(channel: Int, offset: T, scale: T) -> CGImage? {
         guard shape.count == 3 else {
             print("Expected a multi-array with 3 dimensions, got \(shape)")
             return nil
@@ -326,7 +322,42 @@ extension MultiArray {
                 a[y, x] = self[channel, y, x]
             }
         }
-        return a.image(offset: offset, scale: scale)
+        return a.cgImage(offset: offset, scale: scale)
+    }
+}
+
+
+#if canImport(UIKit)
+
+import UIKit
+
+extension MultiArray {
+    /**
+     Converts the multi-array to a UIImage.
+     
+     Use the `offset` and `scale` parameters to put the values from the array in
+     the range [0, 255]. The offset is added first, then the result is multiplied
+     by the scale.
+     
+     For example: if the range of the data is [0, 1), use `offset: 0` and
+     `scale: 255`. If the range is [-1, 1], use `offset: 1` and `scale: 127.5`.
+     */
+    public func image(offset: T, scale: T) -> UIImage? {
+        let cgImg = cgImage(offset: offset, scale: scale)
+        
+        return cgImg.map { UIImage(cgImage: $0) }
+    }
+    
+    /**
+     Converts a single channel from the multi-array to a grayscale UIImage.
+     
+     - Note: The multi-array must have shape (channels, height, width). If your
+     array has a different shape, use `reshape()` or `transpose()` first.
+     */
+    public func image(channel: Int, offset: T, scale: T) -> UIImage? {
+        let cgImg = cgImage(channel: channel, offset: offset, scale: scale)
+        
+        return cgImg.map { UIImage(cgImage: $0) }
     }
 }
 

--- a/CoreMLHelpers/NonMaxSuppression.swift
+++ b/CoreMLHelpers/NonMaxSuppression.swift
@@ -21,7 +21,6 @@
 */
 
 import Foundation
-import UIKit
 import CoreML
 import Accelerate
 

--- a/CoreMLHelpers/UIImage+CVPixelBuffer.swift
+++ b/CoreMLHelpers/UIImage+CVPixelBuffer.swift
@@ -23,7 +23,6 @@
 #if canImport(UIKit)
 
 import UIKit
-import VideoToolbox
 
 extension UIImage {
   /**
@@ -93,10 +92,7 @@ extension UIImage {
    NOTE: This only works for RGB pixel buffers, not for grayscale.
   */
   public convenience init?(pixelBuffer: CVPixelBuffer) {
-    var cgImage: CGImage?
-    VTCreateCGImageFromCVPixelBuffer(pixelBuffer, options: nil, imageOut: &cgImage)
-
-    if let cgImage = cgImage {
+    if let cgImage = CGImage.create(pixelBuffer: pixelBuffer) {
       self.init(cgImage: cgImage)
     } else {
       return nil
@@ -107,10 +103,7 @@ extension UIImage {
    Creates a new UIImage from a CVPixelBuffer, using Core Image.
   */
   public convenience init?(pixelBuffer: CVPixelBuffer, context: CIContext) {
-    let ciImage = CIImage(cvPixelBuffer: pixelBuffer)
-    let rect = CGRect(x: 0, y: 0, width: CVPixelBufferGetWidth(pixelBuffer),
-                                  height: CVPixelBufferGetHeight(pixelBuffer))
-    if let cgImage = context.createCGImage(ciImage, from: rect) {
+    if let cgImage = CGImage.create(pixelBuffer: pixelBuffer, context: context) {
       self.init(cgImage: cgImage)
     } else {
       return nil
@@ -157,20 +150,10 @@ extension UIImage {
                                     bytesPerRow: Int,
                                     colorSpace: CGColorSpace,
                                     alphaInfo: CGImageAlphaInfo) -> UIImage? {
-    var image: UIImage?
-    bytes.withUnsafeBytes { ptr in
-      if let context = CGContext(data: UnsafeMutableRawPointer(mutating: ptr.baseAddress!),
-                                 width: width,
-                                 height: height,
-                                 bitsPerComponent: 8,
-                                 bytesPerRow: bytesPerRow,
-                                 space: colorSpace,
-                                 bitmapInfo: alphaInfo.rawValue),
-         let cgImage = context.makeImage() {
-        image = UIImage(cgImage: cgImage, scale: scale, orientation: orientation)
-      }
-    }
-    return image
+    
+    let cgImage = CGImage.fromByteArray(bytes, width: width, height: height, bytesPerRow: bytesPerRow, colorSpace: colorSpace, alphaInfo: alphaInfo)
+    
+    return cgImage.map { UIImage(cgImage: $0, scale: scale, orientation: orientation) }
   }
 }
 

--- a/CoreMLHelpers/UIImage+CVPixelBuffer.swift
+++ b/CoreMLHelpers/UIImage+CVPixelBuffer.swift
@@ -20,6 +20,8 @@
   IN THE SOFTWARE.
 */
 
+#if canImport(UIKit)
+
 import UIKit
 import VideoToolbox
 
@@ -171,3 +173,5 @@ extension UIImage {
     return image
   }
 }
+
+#endif

--- a/Demo/Demo.xcodeproj/project.pbxproj
+++ b/Demo/Demo.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		7B5603661F470A1D004635EE /* cat.bin in Resources */ = {isa = PBXBuildFile; fileRef = 7B5603651F470A1D004635EE /* cat.bin */; };
 		7B5603681F470C60004635EE /* MLMultiArray+Image.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B5603671F470C60004635EE /* MLMultiArray+Image.swift */; };
 		7B56036C1F47659C004635EE /* Math.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B56036B1F47659C004635EE /* Math.swift */; };
+		A73345A92192728A00C159E4 /* CGImage+CVPixelBuffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A73345A82192728A00C159E4 /* CGImage+CVPixelBuffer.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -89,6 +90,7 @@
 		7B5603651F470A1D004635EE /* cat.bin */ = {isa = PBXFileReference; lastKnownFileType = archive.macbinary; name = cat.bin; path = ../../Images/cat.bin; sourceTree = "<group>"; };
 		7B5603671F470C60004635EE /* MLMultiArray+Image.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "MLMultiArray+Image.swift"; path = "../../CoreMLHelpers/MLMultiArray+Image.swift"; sourceTree = "<group>"; };
 		7B56036B1F47659C004635EE /* Math.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = Math.swift; path = ../../CoreMLHelpers/Math.swift; sourceTree = "<group>"; };
+		A73345A82192728A00C159E4 /* CGImage+CVPixelBuffer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "CGImage+CVPixelBuffer.swift"; path = "../../CoreMLHelpers/CGImage+CVPixelBuffer.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -184,6 +186,7 @@
 			isa = PBXGroup;
 			children = (
 				7B4A36241F35E760009A6364 /* Array.swift */,
+				A73345A82192728A00C159E4 /* CGImage+CVPixelBuffer.swift */,
 				7B4AFF8D1F40874000AF62F3 /* CoreMLHelpers.h */,
 				7B4A362D1F35F062009A6364 /* CVPixelBuffer+Helpers.swift */,
 				7B4AFF8E1F40874000AF62F3 /* Info.plist */,
@@ -368,6 +371,7 @@
 				7B4AFF9E1F408A1400AF62F3 /* UIImage+CVPixelBuffer.swift in Sources */,
 				7B4AFFA11F408AFD00AF62F3 /* Array.swift in Sources */,
 				7B4AFFA01F408AF700AF62F3 /* MultiArray.swift in Sources */,
+				A73345A92192728A00C159E4 /* CGImage+CVPixelBuffer.swift in Sources */,
 				7B5603681F470C60004635EE /* MLMultiArray+Image.swift in Sources */,
 				7B4AFFA31F408B0400AF62F3 /* Predictions.swift in Sources */,
 				7B4AFFAA1F4095B200AF62F3 /* NonMaxSuppression.swift in Sources */,

--- a/Demo/Demo.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Demo/Demo.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
1. There were some codes depending on `UIKit`. Wrap them with `#if canImport(UIKit)`.
1. There were no `CGImage` methods. Add them similar to `UIKit`'s.

I also change `UIImage`'s methods to use corresponding `CGImage`'s methods. But left `UIImage.pixelBuffer` alone since [`UIImage.cgImage`](https://developer.apple.com/documentation/uikit/uiimage/1624147-cgimage) can be `nil`.