### PR TITLE
Fix to support the expected MLMultiArray shape for grayscale

### DIFF
--- a/CoreMLHelpers/MLMultiArray+Image.swift
+++ b/CoreMLHelpers/MLMultiArray+Image.swift
@@ -146,7 +146,13 @@ extension MLMultiArray {
         print("Invalid axes \(axes) for shape \(shape)")
         return nil
       }
+    } else if shape.count == 2 {
+      // Expected shape for grayscale is (height, width)
+      heightAxis = 0
+      widthAxis = 1
+      channelAxis = -1 // Never be used
     } else {
+      // Expected shape for color is (channels, height, width)
       channelAxis = 0
       heightAxis = 1
       widthAxis = 2


### PR DESCRIPTION
According to the comment for `cgImage(min:max:)` method, the shape of `MLMultiArray` can be `(height, width)` when it's a grayscale image.

> The multi-array must have at least 2 dimensions for a grayscale image, or
     at least 3 dimensions for a color image.

>  The default expected shape is (height, width) or (channels, height, width).


However, it always crashed when inputting `(height, width)` shaped `MLMultiArray` object. Because it always set following indices in `toRawBytes` method even when the image was grayscale and the shape was 2-dimensions.

```
                channelAxis = 0
                heightAxis = 1
                widthAxis = 2
```

