### PR TITLE
Support Swift Package Manager

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,24 @@
+// swift-tools-version:5.1
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "CoreMLHelpers",
+    platforms: [.iOS(.v11)],
+    products: [
+        .library(
+            name: "CoreMLHelpers",
+            targets: ["CoreMLHelpers"]),
+    ],
+    dependencies: [
+        // Dependencies declare other packages that this package depends on.
+        // .package(url: /* package url */, from: "1.0.0"),
+    ],
+    targets: [
+        .target(
+            name: "CoreMLHelpers",
+            dependencies: [],
+            path: "CoreMLHelpers"),
+    ]
+)


### PR DESCRIPTION
You need to publish a version tag with the format `x.x.x` (e.g. `0.4.0`).