### PR TITLE
Fix to cropping when rotate

### DIFF
--- a/CoreMLHelpers/UIImage+Extensions.swift
+++ b/CoreMLHelpers/UIImage+Extensions.swift
@@ -52,7 +52,7 @@ extension UIImage {
       // Trim off the extremely small float value to prevent core graphics from rounding it up
       newSize.width = floor(newSize.width)
       newSize.height = floor(newSize.height)
-      let renderer = UIGraphicsImageRenderer(size:self.size)
+      let renderer = UIGraphicsImageRenderer(size:newSize)
       let image = renderer.image { rendererContext in
           let context = rendererContext.cgContext
           //rotate from center


### PR DESCRIPTION
Previous code was cropping image corners. I fixed this.

Previous
<img width="414" alt="Screen Shot 2020-12-16 at 12 00 58" src="https://user-images.githubusercontent.com/2404074/102327516-e7b56080-3f96-11eb-8a2d-28d7cd8c7dae.png">
Now
<img width="328" alt="Screen Shot 2020-12-16 at 12 01 14" src="https://user-images.githubusercontent.com/2404074/102327534-ed12ab00-3f96-11eb-8bea-c2c856c7fe41.png">

