### PR TITLE
add a optional contentMode param for resizePixelBuffer

### DIFF
--- a/CoreMLHelpers/CVPixelBuffer+Resize.swift
+++ b/CoreMLHelpers/CVPixelBuffer+Resize.swift
@@ -96,7 +96,7 @@ public func resizePixelBuffer(from srcPixelBuffer: CVPixelBuffer,
           startX = Int(Float(scaleWidth - fittedWidth) / 2.0)
           startY = 0
       }
-      let offset = 4 * (dstBytesPerRow * startY + startX)
+      let offset = startY * dstBytesPerRow + startX * 4
 
       dstBuffer = vImage_Buffer(data: dstData + offset,
                               height: vImagePixelCount(fittedHeight),


### PR DESCRIPTION
defaults to fill (current behavior) and added the ability to fit. 
.fit param center fits an image in the pixelbuffer while maintaining aspect ratio